### PR TITLE
more idiomatic way to configure master and slave machines and newest ubuntu image

### DIFF
--- a/v3.multinode.config_map/Vagrantfile
+++ b/v3.multinode.config_map/Vagrantfile
@@ -33,8 +33,6 @@ Vagrant.configure("2") do |config|
               vb.name = node_name
               vb.customize ["modifyvm", :id, "--memory", info[:mem], "--cpus", info[:cpus], "--hwvirtex", "on"]
             end # end provider
-            cfg.vm.provision "shell",
-                inline: "apt-get update; apt-get install -y ansible"
             cfg.vm.provision "ansible" do |ansible|
                 ansible.playbook = "#{info[:playbook]}"
                 ansible.extra_vars = {

--- a/v3.multinode.config_map/Vagrantfile
+++ b/v3.multinode.config_map/Vagrantfile
@@ -21,6 +21,8 @@ cluster = {
 
 Vagrant.configure("2") do |config|
 
+    config.vbguest.iso_path = "https://download.virtualbox.org/virtualbox/6.1.18/VBoxGuestAdditions_6.1.18.iso"
+
     cluster.each_with_index do |(node_name, info), index|
         config.ssh.insert_key = false
         config.vm.define node_name do |cfg|
@@ -31,6 +33,8 @@ Vagrant.configure("2") do |config|
               vb.name = node_name
               vb.customize ["modifyvm", :id, "--memory", info[:mem], "--cpus", info[:cpus], "--hwvirtex", "on"]
             end # end provider
+            cfg.vm.provision "shell",
+                inline: "apt-get update; apt-get install -y ansible"
             cfg.vm.provision "ansible" do |ansible|
                 ansible.playbook = "#{info[:playbook]}"
                 ansible.extra_vars = {

--- a/v3.multinode.config_map/Vagrantfile
+++ b/v3.multinode.config_map/Vagrantfile
@@ -1,0 +1,42 @@
+IMAGE_NAME = "ubuntu/groovy64"
+
+CPU_MASTER = 2
+CPU_WORKER = 1
+
+MEMORY_MB_MASTER = 2048
+MEMORY_MB_WORKER = 1024
+
+PLAYBOOK_MASTER = "kubernetes-setup/master-playbook.yml"
+PLAYBOOK_WORKER = "kubernetes-setup/worker-playbook.yml"
+
+# Be careful that this matches with values in playbooks:
+# master: 192.168.50.11
+HOST_SUBNET="192.168.50"
+
+cluster = {
+  "master" => { :ip => "#{HOST_SUBNET}.11", :cpus => CPU_MASTER, :mem => MEMORY_MB_MASTER, :playbook => PLAYBOOK_MASTER },
+  "worker-1" => { :ip => "#{HOST_SUBNET}.12", :cpus => CPU_WORKER, :mem => MEMORY_MB_WORKER, :playbook => PLAYBOOK_WORKER },
+  "worker-2" => { :ip => "#{HOST_SUBNET}.13", :cpus => CPU_WORKER, :mem => MEMORY_MB_WORKER, :playbook => PLAYBOOK_WORKER }
+}
+
+Vagrant.configure("2") do |config|
+
+    cluster.each_with_index do |(node_name, info), index|
+        config.ssh.insert_key = false
+        config.vm.define node_name do |cfg|
+            cfg.vm.provider :virtualbox do |vb, override|
+              config.vm.box = IMAGE_NAME
+              override.vm.network :private_network, ip: "#{info[:ip]}"
+              override.vm.hostname = node_name
+              vb.name = node_name
+              vb.customize ["modifyvm", :id, "--memory", info[:mem], "--cpus", info[:cpus], "--hwvirtex", "on"]
+            end # end provider
+            cfg.vm.provision "ansible" do |ansible|
+                ansible.playbook = "#{info[:playbook]}"
+                ansible.extra_vars = {
+                node_ip: "#{info[:ip]}"
+                }
+            end
+        end # end config
+    end # end cluster
+end # end Vagrant.configure

--- a/v3.multinode.config_map/kubernetes-setup/join-command
+++ b/v3.multinode.config_map/kubernetes-setup/join-command
@@ -1,0 +1,1 @@
+kubeadm join 192.168.50.11:6443 --token yej8en.3gmw10ra8y2vdiqa     --discovery-token-ca-cert-hash sha256:d250501e4628e5d955456b96d40f87e1b57385317fcd798a2cd71d5cf61b5e01 

--- a/v3.multinode.config_map/kubernetes-setup/join-command
+++ b/v3.multinode.config_map/kubernetes-setup/join-command
@@ -1,1 +1,1 @@
-kubeadm join 192.168.50.11:6443 --token yej8en.3gmw10ra8y2vdiqa     --discovery-token-ca-cert-hash sha256:d250501e4628e5d955456b96d40f87e1b57385317fcd798a2cd71d5cf61b5e01 
+kubeadm join 192.168.50.11:6443 --token 2lklm6.dwna44v3b3xs1rra --discovery-token-ca-cert-hash sha256:5ea32189a3377e4b6c98f06ba75321b0877fc5212b3913cbe02eadcc49437c69 

--- a/v3.multinode.config_map/kubernetes-setup/master-playbook.yml
+++ b/v3.multinode.config_map/kubernetes-setup/master-playbook.yml
@@ -1,0 +1,126 @@
+---
+- hosts: all
+  become: true
+  tasks:
+  - name: Install packages that allow apt to be used over HTTPS
+    apt:
+      name: "{{ packages }}"
+      state: present
+      update_cache: yes
+    vars:
+      packages:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gnupg-agent
+      - software-properties-common
+
+  - name: Add an apt signing key for Docker
+    apt_key:
+      url: https://download.docker.com/linux/ubuntu/gpg
+      state: present
+
+  - name: Add apt repository for stable version
+    apt_repository:
+      repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable
+      state: present
+
+  - name: Install docker and its dependecies
+    apt: 
+      name: "{{ packages }}"
+      state: present
+      update_cache: yes
+    vars:
+      packages:
+      - docker-ce 
+      - docker-ce-cli 
+      - containerd.io
+    notify:
+      - docker status
+
+  - name: Add vagrant user to docker group
+    user:
+      name: vagrant
+      group: docker
+
+  - name: Remove swapfile from /etc/fstab
+    mount:
+      name: "{{ item }}"
+      fstype: swap
+      state: absent
+    with_items:
+      - swap
+      - none
+
+  - name: Disable swap
+    command: swapoff -a
+    when: ansible_swaptotal_mb > 0
+
+  - name: Add an apt signing key for Kubernetes
+    apt_key:
+      url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
+      state: present
+
+  - name: Adding apt repository for Kubernetes
+    apt_repository:
+      repo: deb https://apt.kubernetes.io/ kubernetes-xenial main
+      state: present
+      filename: kubernetes.list
+
+  - name: Install Kubernetes binaries
+    apt: 
+      name: "{{ packages }}"
+      state: present
+      update_cache: yes
+    vars:
+      packages:
+        - kubelet 
+        - kubeadm 
+        - kubectl
+
+          #  - name: Configure node ip
+          #    lineinfile:
+          #      path: /etc/default/kubelet
+          #      line: KUBELET_EXTRA_ARGS=--node-ip={{ node_ip }}
+
+  - name: Restart kubelet
+    service:
+      name: kubelet
+      daemon_reload: yes
+      state: restarted
+
+  - name: Initialize the Kubernetes cluster using kubeadm
+    command: kubeadm init --apiserver-advertise-address="192.168.50.11" --apiserver-cert-extra-sans="192.168.50.11"  --node-name master --pod-network-cidr=192.168.0.0/16
+
+  - name: Setup kubeconfig for vagrant user
+    command: "{{ item }}"
+    with_items:
+     - mkdir -p /home/vagrant/.kube
+     - cp -i /etc/kubernetes/admin.conf /home/vagrant/.kube/config
+     - chown -R vagrant:vagrant /home/vagrant/.kube/
+
+       #- name: Install calico pod network
+       #  become: false
+       # command: kubectl create -f https://docs.projectcalico.org/v3.4/getting-started/kubernetes/installation/hosted/calico.yaml
+  - name: Install calico pod network operator
+    become: false
+    command: kubectl create -f https://docs.projectcalico.org/manifests/tigera-operator.yaml
+
+  - name: Install calico pod network crds
+    become: false
+    command: kubectl create -f https://docs.projectcalico.org/manifests/custom-resources.yaml
+
+  - name: Generate join command
+    command: kubeadm token create --print-join-command
+    register: join_command
+
+  - name: Copy join command to local file
+    become: false
+    local_action: copy content="{{ join_command.stdout_lines[0] }}" dest="./join-command"
+
+
+  handlers:
+    - name: docker status
+      service: name=docker state=started
+
+

--- a/v3.multinode.config_map/kubernetes-setup/master-playbook.yml.orig
+++ b/v3.multinode.config_map/kubernetes-setup/master-playbook.yml.orig
@@ -1,0 +1,118 @@
+---
+- hosts: all
+  become: true
+  tasks:
+  - name: Install packages that allow apt to be used over HTTPS
+    apt:
+      name: "{{ packages }}"
+      state: present
+      update_cache: yes
+    vars:
+      packages:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gnupg-agent
+      - software-properties-common
+
+  - name: Add an apt signing key for Docker
+    apt_key:
+      url: https://download.docker.com/linux/ubuntu/gpg
+      state: present
+
+  - name: Add apt repository for stable version
+    apt_repository:
+      repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable
+      state: present
+
+  - name: Install docker and its dependecies
+    apt: 
+      name: "{{ packages }}"
+      state: present
+      update_cache: yes
+    vars:
+      packages:
+      - docker-ce 
+      - docker-ce-cli 
+      - containerd.io
+    notify:
+      - docker status
+
+  - name: Add vagrant user to docker group
+    user:
+      name: vagrant
+      group: docker
+
+  - name: Remove swapfile from /etc/fstab
+    mount:
+      name: "{{ item }}"
+      fstype: swap
+      state: absent
+    with_items:
+      - swap
+      - none
+
+  - name: Disable swap
+    command: swapoff -a
+    when: ansible_swaptotal_mb > 0
+
+  - name: Add an apt signing key for Kubernetes
+    apt_key:
+      url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
+      state: present
+
+  - name: Adding apt repository for Kubernetes
+    apt_repository:
+      repo: deb https://apt.kubernetes.io/ kubernetes-xenial main
+      state: present
+      filename: kubernetes.list
+
+  - name: Install Kubernetes binaries
+    apt: 
+      name: "{{ packages }}"
+      state: present
+      update_cache: yes
+    vars:
+      packages:
+        - kubelet 
+        - kubeadm 
+        - kubectl
+
+  - name: Configure node ip
+    lineinfile:
+      path: /etc/default/kubelet
+      line: KUBELET_EXTRA_ARGS=--node-ip={{ node_ip }}
+
+  - name: Restart kubelet
+    service:
+      name: kubelet
+      daemon_reload: yes
+      state: restarted
+
+  - name: Initialize the Kubernetes cluster using kubeadm
+    command: kubeadm init --apiserver-advertise-address="192.168.50.10" --apiserver-cert-extra-sans="192.168.50.10"  --node-name k8s-master --pod-network-cidr=192.168.0.0/16
+
+  - name: Setup kubeconfig for vagrant user
+    command: "{{ item }}"
+    with_items:
+     - mkdir -p /home/vagrant/.kube
+     - cp -i /etc/kubernetes/admin.conf /home/vagrant/.kube/config
+     - chown vagrant:vagrant /home/vagrant/.kube/config
+
+  - name: Install calico pod network
+    become: false
+    command: kubectl create -f https://docs.projectcalico.org/v3.4/getting-started/kubernetes/installation/hosted/calico.yaml
+
+  - name: Generate join command
+    command: kubeadm token create --print-join-command
+    register: join_command
+
+  - name: Copy join command to local file
+    local_action: copy content="{{ join_command.stdout_lines[0] }}" dest="./join-command"
+
+
+  handlers:
+    - name: docker status
+      service: name=docker state=started
+
+

--- a/v3.multinode.config_map/kubernetes-setup/worker-playbook.yml
+++ b/v3.multinode.config_map/kubernetes-setup/worker-playbook.yml
@@ -1,0 +1,102 @@
+---
+- hosts: all
+  become: true
+  tasks:
+  - name: Install packages that allow apt to be used over HTTPS
+    apt:
+      name: "{{ packages }}"
+      state: present
+      update_cache: yes
+    vars:
+      packages:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gnupg-agent
+      - software-properties-common
+
+  - name: Add an apt signing key for Docker
+    apt_key:
+      url: https://download.docker.com/linux/ubuntu/gpg
+      state: present
+
+  - name: Add apt repository for stable version
+    apt_repository:
+      repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable
+      state: present
+
+  - name: Install docker and its dependecies
+    apt: 
+      name: "{{ packages }}"
+      state: present
+      update_cache: yes
+    vars:
+      packages:
+      - docker-ce 
+      - docker-ce-cli 
+      - containerd.io
+    notify:
+      - docker status
+
+  - name: Add vagrant user to docker group
+    user:
+      name: vagrant
+      group: docker
+
+  - name: Remove swapfile from /etc/fstab
+    mount:
+      name: "{{ item }}"
+      fstype: swap
+      state: absent
+    with_items:
+      - swap
+      - none
+
+  - name: Disable swap
+    command: swapoff -a
+    when: ansible_swaptotal_mb > 0
+
+  - name: Add an apt signing key for Kubernetes
+    apt_key:
+      url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
+      state: present
+
+  - name: Adding apt repository for Kubernetes
+    apt_repository:
+      repo: deb https://apt.kubernetes.io/ kubernetes-xenial main
+      state: present
+      filename: kubernetes.list
+
+  - name: Install Kubernetes binaries
+    apt: 
+      name: "{{ packages }}"
+      state: present
+      update_cache: yes
+    vars:
+      packages:
+        - kubelet 
+        - kubeadm 
+        - kubectl
+
+          #  - name: Configure node ip
+          #    lineinfile:
+          #      path: /etc/default/kubelet
+          #      line: KUBELET_EXTRA_ARGS=--node-ip={{ node_ip }}
+
+  - name: Restart kubelet
+    service:
+      name: kubelet
+      daemon_reload: yes
+      state: restarted
+
+  - name: Copy the join command to server location
+    copy: src=join-command dest=/tmp/join-command.sh mode=0777
+
+  - name: Join the node to cluster
+    command: sh /tmp/join-command.sh
+
+  handlers:
+    - name: docker status
+      service: name=docker state=started
+
+

--- a/v3.multinode.config_map/redo.sh
+++ b/v3.multinode.config_map/redo.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -x
+time vagrant destroy -f
+time vagrant up
+


### PR DESCRIPTION
with the v2 implementation of the Vagrant file, it is not possible to set different configurations for master and worker nodes.
The way Vagrant works, or in general Ruby does, the initializations are done lazily and the configuration for worker-2 is passed to all master and worker-1 nodes, resulting in a homogeneous setup.
